### PR TITLE
Add library name prefixes to files in examples folder

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,14 +3,14 @@ Simple tests
 
 Ensure your device works with these simple tests.
 
-.. literalinclude:: ../examples/tone_demo.py
-    :caption: examples/tone_demo.py
+.. literalinclude:: ../examples/simpleio_tone_demo.py
+    :caption: examples/simpleio_tone_demo.py
     :linenos:
 
-.. literalinclude:: ../examples/shift_in_out_demo.py
-    :caption: examples/shift_in_out_demo.py
+.. literalinclude:: ../examples/simpleio_shift_in_out_demo.py
+    :caption: examples/simpleio_shift_in_out_demo.py
     :linenos:
 
-.. literalinclude:: ../examples/map_range_demo.py
-    :caption: examples/map_range_demo.py
+.. literalinclude:: ../examples/simpleio_map_range_demo.py
+    :caption: examples/simpleio_map_range_demo.py
     :linenos:

--- a/examples/simpleio_map_range_demo.py
+++ b/examples/simpleio_map_range_demo.py
@@ -1,5 +1,5 @@
 """
-'map_range_demo.py'.
+'simpleio_map_range_demo.py'.
 
 =================================================
 maps a number from one range to another

--- a/examples/simpleio_shift_in_out_demo.py
+++ b/examples/simpleio_shift_in_out_demo.py
@@ -1,5 +1,5 @@
 """
-'shift_in_out_demo.py'.
+'simpleio_shift_in_out_demo.py'.
 
 =================================================
 shifts data into and out of a data pin

--- a/examples/simpleio_tone_demo.py
+++ b/examples/simpleio_tone_demo.py
@@ -1,5 +1,5 @@
 """
-'tone_demo.py'.
+'simpleio_tone_demo.py'.
 
 =================================================
 a short piezo song using tone()


### PR DESCRIPTION
Pycon sprint!

**It is possible that guides will require updating to match the new example name.**

- Add libraryname_simpletest.py to examples folder
- Add libraryname_ prefix to existing files in examples folder
