### PR TITLE
bitcount argument to shift_out()

### DIFF
--- a/simpleio.py
+++ b/simpleio.py
@@ -182,11 +182,11 @@ def shift_out(data_pin, clock, value, msb_first=True, bitcount=8):
         raise ValueError('bitcount must be positive')
     
     if msb_first:
-        f = lambda : range(bitcount-1, -1, -1)
+        bitsequence = lambda: range(bitcount-1, -1, -1)
     else:
-        f = lambda : range(0, bitcount)
+        bitsequence = lambda: range(0, bitcount)
     
-    for i in f():
+    for i in bitsequence():
         tmpval = bool(value & (1<<i))
         data_pin.value = tmpval
         # toggle clock pin True/False

--- a/simpleio.py
+++ b/simpleio.py
@@ -178,8 +178,8 @@ def shift_out(data_pin, clock, value, msb_first=True, bitcount=8):
             latchpin.value = True
             time.sleep(1.0)
     """
-    if bitcount < 0:
-        raise ValueError('bitcount must be positive')
+    if bitcount < 0 or bitcount > 32:
+        raise ValueError('bitcount must be in range 0..32 inclusive')
     
     if msb_first:
         bitsequence = lambda: range(bitcount-1, -1, -1)

--- a/simpleio.py
+++ b/simpleio.py
@@ -180,12 +180,12 @@ def shift_out(data_pin, clock, value, msb_first=True, bitcount=8):
     """
     if bitcount < 0 or bitcount > 32:
         raise ValueError('bitcount must be in range 0..32 inclusive')
-    
+
     if msb_first:
         bitsequence = lambda: range(bitcount-1, -1, -1)
     else:
         bitsequence = lambda: range(0, bitcount)
-    
+
     for i in bitsequence():
         tmpval = bool(value & (1<<i))
         data_pin.value = tmpval

--- a/simpleio.py
+++ b/simpleio.py
@@ -126,7 +126,7 @@ def shift_in(data_pin, clock, msb_first=True):
         i += 1
     return value
 
-def shift_out(data_pin, clock, value, msb_first=True):
+def shift_out(data_pin, clock, value, msb_first=True, bitcount=8):
     """
     Shifts out a byte of data one bit at a time. Data gets written to a data
     pin. Then, the clock pulses hi then low
@@ -138,6 +138,7 @@ def shift_out(data_pin, clock, value, msb_first=True):
     :param ~digitalio.DigitalInOut clock: toggled once the data pin is set
     :param bool msb_first: True when the first bit is most significant
     :param int value: byte to be shifted
+    :param unsigned bitcount: number of bits to shift
 
     Example for Metro M0 Express:
 
@@ -177,14 +178,17 @@ def shift_out(data_pin, clock, value, msb_first=True):
             latchpin.value = True
             time.sleep(1.0)
     """
-    value = value&0xFF
-    for i in range(0, 8):
-        if msb_first:
-            tmpval = bool(value & (1 << (7-i)))
-            data_pin.value = tmpval
-        else:
-            tmpval = bool((value & (1 << i)))
-            data_pin.value = tmpval
+    if bitcount < 0:
+        raise ValueError
+    
+    if msb_first:
+        f = lambda : range(bitcount-1, -1, -1)
+    else:
+        f = lambda : range(0, bitcount)
+    
+    for i in f():
+        tmpval = bool(value & (1<<i))
+        data_pin.value = tmpval
         # toggle clock pin True/False
         clock.value = True
         clock.value = False

--- a/simpleio.py
+++ b/simpleio.py
@@ -179,7 +179,7 @@ def shift_out(data_pin, clock, value, msb_first=True, bitcount=8):
             time.sleep(1.0)
     """
     if bitcount < 0:
-        raise ValueError
+        raise ValueError('bitcount must be positive')
     
     if msb_first:
         f = lambda : range(bitcount-1, -1, -1)


### PR DESCRIPTION
Changes allow arbitrary bit count to be handled by shift_out().  Default parameter value preserves old behavior.  Note this does fail when bitcount > 2^31