### PR TITLE
tone: Work with 4.x, 5.0; AudioOut and PWMAudioOut

### DIFF
--- a/simpleio.py
+++ b/simpleio.py
@@ -33,6 +33,7 @@ import array
 import digitalio
 import pulseio
 
+#pylint: disable=invalid-name
 def _AudioOut(pin):
     try:
         import audioio
@@ -66,6 +67,7 @@ def _RawSample(buffer):
         return audioio.RawSample(buffer)
 
     raise RuntimeError("AudioOut not available")
+#pylint: enable=invalid-name
 
 def tone(pin, frequency, duration=1, length=100):
     """

--- a/simpleio.py
+++ b/simpleio.py
@@ -31,7 +31,10 @@ import time
 import array
 import digitalio
 import pulseio
-
+try:
+    import audiocore
+except ImportError:
+    import audioio as audiocore
 try:
     from audioio import AudioOut
 except ImportError:
@@ -39,11 +42,6 @@ except ImportError:
         from audiopwmio import PWMAudioOut as AudioOut
     except ImportError:
         pass # not always supported by every board!
-
-try:
-    import audiocore
-except ImportError:
-    import audioio as audiocore
 
 def tone(pin, frequency, duration=1, length=100):
     """

--- a/simpleio.py
+++ b/simpleio.py
@@ -34,7 +34,10 @@ import pulseio
 try:
     import audiocore
 except ImportError:
-    import audioio as audiocore
+    try:
+        import audioio as audiocore
+    except ImportError:
+        pass # not always supported by every board!
 try:
     from audioio import AudioOut
 except ImportError:

--- a/simpleio.py
+++ b/simpleio.py
@@ -28,7 +28,6 @@ The `simpleio` module contains classes to provide simple access to IO.
 * Author(s): Scott Shawcroft
 """
 import time
-import sys
 import array
 import digitalio
 import pulseio

--- a/simpleio.py
+++ b/simpleio.py
@@ -29,13 +29,43 @@ The `simpleio` module contains classes to provide simple access to IO.
 """
 import time
 import sys
-try:
-    import audioio
-except ImportError:
-    pass # not always supported by every board!
 import array
 import digitalio
 import pulseio
+
+def _AudioOut(pin):
+    try:
+        import audioio
+    except ImportError:
+        pass
+    else:
+        return audioio.AudioOut(pin)
+
+    try:
+        import audiopwmio
+    except ImportError:
+        pass
+    else:
+        return audiopwmio.PWMAudioOut(pin)
+
+    raise RuntimeError("AudioOut not available")
+
+def _RawSample(buffer):
+    try:
+        import audiocore
+    except ImportError:
+        pass
+    else:
+        return audiocore.RawSample(buffer)
+
+    try:
+        import audioio
+    except ImportError:
+        pass
+    else:
+        return audioio.RawSample(buffer)
+
+    raise RuntimeError("AudioOut not available")
 
 def tone(pin, frequency, duration=1, length=100):
     """
@@ -61,21 +91,13 @@ def tone(pin, frequency, duration=1, length=100):
         square_wave = array.array("H", [0] * sample_length)
         for i in range(sample_length / 2):
             square_wave[i] = 0xFFFF
-        if sys.implementation.version[0] >= 3:
-            square_wave_sample = audioio.RawSample(square_wave)
-            square_wave_sample.sample_rate = int(len(square_wave) * frequency)
-            with audioio.AudioOut(pin) as dac:
-                if not dac.playing:
-                    dac.play(square_wave_sample, loop=True)
-                    time.sleep(duration)
-                dac.stop()
-        else:
-            sample_tone = audioio.AudioOut(pin, square_wave)
-            sample_tone.frequency = int(len(square_wave) * frequency)
-            if not sample_tone.playing:
-                sample_tone.play(loop=True)
+        square_wave_sample = _RawSample(square_wave)
+        square_wave_sample.sample_rate = int(len(square_wave) * frequency)
+        with _AudioOut(pin) as dac:
+            if not dac.playing:
+                dac.play(square_wave_sample, loop=True)
                 time.sleep(duration)
-            sample_tone.stop()
+            dac.stop()
 
 
 

--- a/simpleio.py
+++ b/simpleio.py
@@ -32,41 +32,18 @@ import array
 import digitalio
 import pulseio
 
-#pylint: disable=invalid-name
-def _AudioOut(pin):
+try:
+    from audioio import AudioOut
+except ImportError:
     try:
-        import audioio
+        from audiopwmio import PWMAudioOut as AudioOut
     except ImportError:
-        pass
-    else:
-        return audioio.AudioOut(pin)
+        pass # not always supported by every board!
 
-    try:
-        import audiopwmio
-    except ImportError:
-        pass
-    else:
-        return audiopwmio.PWMAudioOut(pin)
-
-    raise RuntimeError("AudioOut not available")
-
-def _RawSample(buffer):
-    try:
-        import audiocore
-    except ImportError:
-        pass
-    else:
-        return audiocore.RawSample(buffer)
-
-    try:
-        import audioio
-    except ImportError:
-        pass
-    else:
-        return audioio.RawSample(buffer)
-
-    raise RuntimeError("AudioOut not available")
-#pylint: enable=invalid-name
+try:
+    import audiocore
+except ImportError:
+    import audioio as audiocore
 
 def tone(pin, frequency, duration=1, length=100):
     """
@@ -92,9 +69,9 @@ def tone(pin, frequency, duration=1, length=100):
         square_wave = array.array("H", [0] * sample_length)
         for i in range(sample_length / 2):
             square_wave[i] = 0xFFFF
-        square_wave_sample = _RawSample(square_wave)
+        square_wave_sample = audiocore.RawSample(square_wave)
         square_wave_sample.sample_rate = int(len(square_wave) * frequency)
-        with _AudioOut(pin) as dac:
+        with AudioOut(pin) as dac:
             if not dac.playing:
                 dac.play(square_wave_sample, loop=True)
                 time.sleep(duration)

--- a/simpleio.py
+++ b/simpleio.py
@@ -28,23 +28,23 @@ The `simpleio` module contains classes to provide simple access to IO.
 * Author(s): Scott Shawcroft
 """
 import time
+import sys
 import array
 import digitalio
 import pulseio
 try:
-    import audiocore
-except ImportError:
-    try:
+    # RawSample was moved in CircuitPython 5.x.
+    if sys.implementation.version[0] >= 5:
+        import audiocore
+    else:
         import audioio as audiocore
-    except ImportError:
-        pass # not always supported by every board!
-try:
-    from audioio import AudioOut
-except ImportError:
+    # Some boards have AudioOut (true DAC), others have PWMAudioOut.
     try:
-        from audiopwmio import PWMAudioOut as AudioOut
+        from audioio import AudioOut
     except ImportError:
-        pass # not always supported by every board!
+        from audiopwmio import PWMAudioOut as AudioOut
+except ImportError:
+    pass # not always supported by every board!
 
 def tone(pin, frequency, duration=1, length=100):
     """


### PR DESCRIPTION
.. by creating new private functions for getting the right AudioOut and RawSample objects.

INCOMPATIBLE CHANGE: this removes support for CircuitPython versions before 3.x in tone()

Testing performed: On CPB, `tone(board.SPEAKER, 440)`.  On Metro M4 Express, `tone(board.A0, 440).  Both tests were using CircuitPython 5.0.alpha versions.

Closes: #45