### PR TITLE
Add temperature conversion helper to SimpleIO

### DIFF
--- a/examples/simpleio_convert_temp_simpletest.py
+++ b/examples/simpleio_convert_temp_simpletest.py
@@ -1,0 +1,18 @@
+"""
+'simpleio_convert_temp_simpletest.py'.
+
+=================================================
+Converts a temperature value to Celsius or Fahrenheit
+"""
+from simpleio import *
+
+while True:
+    # Convert from Fahrenheit to Celsius
+    sensor_1_f = 212  # sensor temperature in degrees Fahrenheit
+    sensor_1_c = convert_temp(f=sensor_1_f)
+    print("Sensor: %6.2f Fahrenheit = %6.2f Celsius" % (sensor_1_f, sensor_1_c))
+
+    # Convert from Celsius to Fahrenheit
+    sensor_2_c = 100  # sensor temperature in degrees Celsius
+    sensor_2_f = convert_temp(c=sensor_2_c)
+    print("Sensor: %6.2f Celsius = %6.2f Fahrenheit" % (sensor_2_c, sensor_2_f))

--- a/examples/simpleio_convert_temp_simpletest.py
+++ b/examples/simpleio_convert_temp_simpletest.py
@@ -4,7 +4,7 @@
 =================================================
 Converts a temperature value to Celsius or Fahrenheit
 """
-from simpleio import *
+from simpleio import convert_temp
 
 while True:
     # Convert from Fahrenheit to Celsius

--- a/examples/simpleio_convert_temp_simpletest.py
+++ b/examples/simpleio_convert_temp_simpletest.py
@@ -9,10 +9,10 @@ from simpleio import convert_temp
 while True:
     # Convert from Fahrenheit to Celsius
     sensor_1_f = 212  # sensor temperature in degrees Fahrenheit
-    sensor_1_c = convert_temp(f=sensor_1_f)
+    sensor_1_c = convert_temp(temp_f=sensor_1_f)
     print("Sensor: %6.2f Fahrenheit = %6.2f Celsius" % (sensor_1_f, sensor_1_c))
 
     # Convert from Celsius to Fahrenheit
     sensor_2_c = 100  # sensor temperature in degrees Celsius
-    sensor_2_f = convert_temp(c=sensor_2_c)
+    sensor_2_f = convert_temp(temp_c=sensor_2_c)
     print("Sensor: %6.2f Celsius = %6.2f Fahrenheit" % (sensor_2_c, sensor_2_f))

--- a/simpleio.py
+++ b/simpleio.py
@@ -262,3 +262,28 @@ def map_range(x, in_min, in_max, out_min, out_max):
     if out_min <= out_max:
         return max(min(mapped, out_max), out_min)
     return min(max(mapped, out_max), out_min)
+
+def convert_temp(f=None, c=None):
+    """
+    Converts a temperature value to Celsius or Fahrenheit
+
+    :param f: Fahrenheit temperature value
+    :param c: Celsius temperature value
+
+    :return: Returns Fahrenheit value for Celsius input; Celsius value for Fahrenheit input; None for no input
+    :rtype: float
+
+    Example:
+
+    .. code-block:: python
+
+    # Convert from Fahrenheit to Celsius
+    convert_temp(f=212)  # returns a value of 100.0
+
+    # Convert from Celsius to Fahrenheit
+    convert_temp(c=100)  # returns a value of 212.0
+
+    """
+    if f != None and c == None: return (f - 32) * (5 / 9)  # F to C
+    if f == None and c != None: return ((9 / 5) * c) + 32  # C to F
+    return None

--- a/simpleio.py
+++ b/simpleio.py
@@ -270,7 +270,7 @@ def convert_temp(temp_f=None, temp_c=None):
     :param temp_f: Fahrenheit temperature value
     :param temp_c: Celsius temperature value
 
-    :return: Returns Fahrenheit value for Celsius input; Celsius value for Fahrenheit input; None for no input
+    :return: Returns Fahrenheit value for Celsius; Celsius value for Fahrenheit; otherwise None
     :rtype: float
 
     Example:

--- a/simpleio.py
+++ b/simpleio.py
@@ -263,12 +263,12 @@ def map_range(x, in_min, in_max, out_min, out_max):
         return max(min(mapped, out_max), out_min)
     return min(max(mapped, out_max), out_min)
 
-def convert_temp(f=None, c=None):
+def convert_temp(temp_f=None, temp_c=None):
     """
     Converts a temperature value to Celsius or Fahrenheit
 
-    :param f: Fahrenheit temperature value
-    :param c: Celsius temperature value
+    :param temp_f: Fahrenheit temperature value
+    :param temp_c: Celsius temperature value
 
     :return: Returns Fahrenheit value for Celsius input; Celsius value for Fahrenheit input; None for no input
     :rtype: float
@@ -278,12 +278,14 @@ def convert_temp(f=None, c=None):
     .. code-block:: python
 
     # Convert from Fahrenheit to Celsius
-    convert_temp(f=212)  # returns a value of 100.0
+    convert_temp(temp_f=212)  # returns a value of 100.0
 
     # Convert from Celsius to Fahrenheit
-    convert_temp(c=100)  # returns a value of 212.0
+    convert_temp(temp_c=100)  # returns a value of 212.0
 
     """
-    if f != None and c == None: return (f - 32) * (5 / 9)  # F to C
-    if f == None and c != None: return ((9 / 5) * c) + 32  # C to F
+    if (temp_f is not None) and (temp_c is None):
+        return (temp_f - 32) * (5 / 9)  # F to C
+    if (temp_f is None) and (temp_c is not None):
+        return ((9 / 5) * temp_c) + 32  # C to F
     return None


### PR DESCRIPTION
_convert_temp(temp_f=None, temp_c=None)_ is an often used Celsius-to-Fahrenheit / Fahrenheit-to-Celsius conversion helper that would like to find a nice home, perhaps in  _SimpleIO_. When a value _temp_f_ is supplied, a value in Celsius is returned; _temp_c_ returns a value in Fahrenheit. _None_ is returned for other input conditions.

The UI syntax is: 
```python
from simpleio import convert_temp

# Convert from Fahrenheit to Celsius
sensor_1_f = 212  # sensor temperature in degrees Fahrenheit
sensor_1_c = convert_temp(temp_f=sensor_1_f)
print("Sensor: %6.2f Fahrenheit = %6.2f Celsius" % (sensor_1_f, sensor_1_c))

# Convert from Celsius to Fahrenheit
sensor_2_c = 100  # sensor temperature in degrees Celsius
sensor_2_f = convert_temp(temp_c=sensor_2_c)
print("Sensor: %6.2f Celsius = %6.2f Fahrenheit" % (sensor_2_c, sensor_2_f))
```
